### PR TITLE
Add support for Cardano Shelley addresses

### DIFF
--- a/src/NMM_Blockchain.php
+++ b/src/NMM_Blockchain.php
@@ -308,7 +308,7 @@ class NMM_Blockchain {
 
 
 	public static function get_ada_address_transactions($address) {
-		$request = 'https://cardanoexplorer.com/api/addresses/summary/' . $address;
+		$request = 'https://explorer.cardano.org/api/addresses/summary/' . $address;
 		$response = wp_remote_get($request);
 
 		if (is_wp_error($response) || $response['response']['code'] !== 200) {
@@ -339,8 +339,8 @@ class NMM_Blockchain {
 			$outputs = $rawTransaction->ctbOutputs;
 
 			foreach ($outputs as $output) {
-				if ($output[0] === $address) {
-					$amount = $output[1]->getCoin;
+				if ($output->ctaAddress === $address) {
+					$amount = $output->ctaAmount->getCoin;
 					$transactions[] = new NMM_Transaction($amount,
 														  10000,
 														  $rawTransaction->ctbTimeIssued,

--- a/src/NMM_Cryptocurrencies.php
+++ b/src/NMM_Cryptocurrencies.php
@@ -244,8 +244,9 @@ class NMM_Cryptocurrencies {
         if ($cryptoId === 'ADA') {
             $match1 = preg_match('/^Ddz[0-9a-zA-Z]{80,120}/', $address);
             $match2 = preg_match('/^Ae2tdPwUPE[0-9a-zA-Z]{46,53}/', $address);
+            $match3 = preg_match('/^addr[0-9a-zA-Z]{99}/', $address);
 
-            return $match1 || $match2;
+            return $match1 || $match2 || $match3;
         }
         if ($cryptoId === 'XTZ') {
             return preg_match('/^tz1[0-9a-zA-Z]{30,39}/', $address);


### PR DESCRIPTION
Added simple check for Shelley style addresses to NMM_Cryptocurrencies.php, does this fully match new address style?

Changed NMM_Blockchain.php to access tx variables by name to avoid "Uncaught Error: Cannot use object of type stdClass as array"

More testing should be done, unsure if this is fully backwards compatible with Byron era addresses / txs, but it should be.